### PR TITLE
Fix msvc runtime linkage for nng, lz4 and libpng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+conan.lock
+conanbuildinfo.txt
+conaninfo.txt
+graph_info.json

--- a/recipes/libpng/conanfile.py
+++ b/recipes/libpng/conanfile.py
@@ -57,6 +57,10 @@ class TemplateConan(ConanFile):
 
         cmake.configure(source_folder=self.name)
 
+        if self.settings.os == "Windows":
+            tools.replace_in_file("CMakeCache.txt", '/MD', '/MT', strict = False)
+            cmake.configure(source_folder=self.name)
+
         cmake.build()
 
     def package(self):

--- a/recipes/lz4/conanfile.py
+++ b/recipes/lz4/conanfile.py
@@ -41,6 +41,10 @@ class Lz4Conan(ConanFile):
         self.cmake_wrapper(cmake, self.settings, self.options)
         cmake.configure(source_folder=os.path.join(self.name, 'contrib', 'cmake_unofficial'))
 
+        if self.settings.os == "Windows":
+            tools.replace_in_file("CMakeCache.txt", '/MD', '/MT', strict = False)
+            cmake.configure(source_folder=os.path.join(self.name, 'contrib', 'cmake_unofficial'))
+
         cmake.build(args=['--target', 'lz4_static'])
 
     def package(self):

--- a/recipes/nng/conanfile.py
+++ b/recipes/nng/conanfile.py
@@ -65,6 +65,10 @@ class NngConan(ConanFile):
 
         cmake.configure(source_folder=self.name)
 
+        if self.settings.os == "Windows":
+            tools.replace_in_file("CMakeCache.txt", '/MD', '/MT', strict = False)
+            cmake.configure(source_folder=self.name)
+
         cmake.build()
 
     def package(self):


### PR DESCRIPTION
The original `conan-*` repos for nng, lz4 and libpng contain this:

```
            # conan doesn't support properly switching runtimes at the moment,
            # need to use this hack in the meantime
            if self.settings.os == 'Windows':
                tools.replace_in_file('CMakeCache.txt', '/MD', '/MT', strict=False)
```

I'm not sure what was done to correct for this in conan-public; but those libraries are currently linking with /MD. This breaks usage of the packages downstream.

The setting "compiler_runtime" *is* being set to `MT`; I don't know why it's not working properly - I don't have context for that...

This PR reinstates the hack and, after rebuilding those packages locally, fixes compilation downstream.