### PR TITLE
build OpenSSH dependencies on non-Windows

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -119,8 +119,10 @@ function Invoke-TlkBuild {
         'lizard',
         'libpng',
         'libjpeg',
+        'libcbor',
         'mbedtls',
         'openssl',
+        'libressl',
         'winpr',
         'freerdp',
         'pcre2',
@@ -128,25 +130,20 @@ function Invoke-TlkBuild {
         'curl'
     )
 
-    if ($Platform -eq 'windows') {
-        $TargetPackages += @('libcbor', 'libressl', 'libfido2', 'openssh')
-    }
-
     if (@('windows','macos','linux') -Contains $Platform) {
         $TargetPackages += @(
             'munit',
             'libvpx',
-            'libwebm'
+            'libwebm',
+            'libfido2'
         )
-
-        # $TargetPackages += @('siquery')
-
-        # if (($Platform -ne 'windows') -or (($Platform -eq 'windows') -and ($Architecture -ne 'arm64'))) {
-        #     $TargetPackages += @('jetsocat')
-        # }
     }
 
-    if ($IsWindows) {
+    if ($Platform -eq 'windows') {
+        $TargetPackages += @('openssh')
+    }
+
+    if ($Platform -eq 'windows') {
         $TargetPackages += @('crashpad')
     }
 

--- a/recipes/libcbor/conanfile.py
+++ b/recipes/libcbor/conanfile.py
@@ -33,9 +33,26 @@ class LibcborConan(ConanFile):
         git.clone(self.url)
         git.checkout(self.branch)
 
+        tools.replace_in_file(os.path.join(folder, 'CMakeLists.txt'),
+            "cmake_minimum_required(VERSION 2.8)",
+            "cmake_minimum_required(VERSION 3.9)")
+
+        tools.replace_in_file(os.path.join(folder, 'CMakeLists.txt'),
+            "set(use_lto FALSE)",
+            "set(use_lto TRUE)")
+
+        tools.replace_in_file(os.path.join(folder, 'CMakeLists.txt'),
+            "    check_ipo_supported(RESULT use_lto)",
+            "    #check_ipo_supported(RESULT use_lto)")
+
     def build(self):
         cmake = CMake(self)
         self.cmake_wrapper(cmake, self.settings, self.options)
+        
+        cmake.definitions['SANITIZE'] = 'OFF'
+        cmake.definitions['WITH_TESTS'] = 'OFF'
+        cmake.definitions['WITH_EXAMPLES'] = 'OFF'
+
         cmake.configure(source_folder=self.name)
         cmake.build()
         cmake.install()

--- a/recipes/libfido2/conanfile.py
+++ b/recipes/libfido2/conanfile.py
@@ -6,11 +6,11 @@ class LibFIDO2Conan(ConanFile):
     exports = 'VERSION'
     version = open(os.path.join('.', 'VERSION'), 'r').read().rstrip()
     license = 'BSD'
-    url = 'https://github.com/PowerShell/libfido2'
+    url = 'https://github.com/awakecoding/libfido2'
     description = 'libfido2'
     settings = 'os', 'arch', 'distro', 'build_type'
     no_copy_source = True
-    branch = version
+    branch = 'devolutions'
     python_requires = "shared/1.0.0@devolutions/stable"
     python_requires_extend = "shared.UtilsBase"
 
@@ -52,16 +52,19 @@ class LibFIDO2Conan(ConanFile):
             cmake.definitions['BUILD_STATIC_LIBS'] = 'ON'
 
         zlib_path = self.deps_cpp_info['zlib'].rootpath
+        cmake.definitions['ZLIB_ROOT_DIR'] = zlib_path
         cmake.definitions['ZLIB_BIN_DIRS'] = os.path.join(zlib_path, 'bin')
         cmake.definitions['ZLIB_INCLUDE_DIRS'] = os.path.join(zlib_path, 'include')
         cmake.definitions['ZLIB_LIBRARY_DIRS'] = os.path.join(zlib_path, 'lib')
 
         libcbor_path = self.deps_cpp_info['libcbor'].rootpath
+        cmake.definitions['CBOR_ROOT_DIR'] = libcbor_path
         cmake.definitions['CBOR_BIN_DIRS'] = os.path.join(libcbor_path, 'bin')
         cmake.definitions['CBOR_INCLUDE_DIRS'] = os.path.join(libcbor_path, 'include')
         cmake.definitions['CBOR_LIBRARY_DIRS'] = os.path.join(libcbor_path, 'lib')
 
         libressl_path = self.deps_cpp_info['libressl'].rootpath
+        cmake.definitions['CRYPTO_ROOT_DIR'] = libressl_path
         cmake.definitions['CRYPTO_BIN_DIRS'] = os.path.join(libressl_path, 'bin')
         cmake.definitions['CRYPTO_INCLUDE_DIRS'] = os.path.join(libressl_path, 'include')
         cmake.definitions['CRYPTO_LIBRARY_DIRS'] = os.path.join(libressl_path, 'lib')


### PR DESCRIPTION
Expand OpenSSH dependency building:

- libcbor (all platforms)
- LibreSSL (all platforms)
- libfido2 (all desktop platforms)

libfido2 is not officially supported on Android and iOS. On Linux, it requires libudev