### PR TITLE
Rebased FreeRDP

### DIFF
--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -47,7 +47,7 @@ jobs:
           - os: macos
             runner: macos-latest
           - os: linux
-            runner: ubuntu-18.04
+            runner: ubuntu-20.04
           - os: ios
             runner: macos-latest
           - os: android

--- a/recipes/freerdp/conanfile.py
+++ b/recipes/freerdp/conanfile.py
@@ -10,7 +10,7 @@ class FreerdpConan(ConanFile):
     url = 'https://github.com/Devolutions/FreeRDP.git'
     description = 'FreeRDP is a free remote desktop protocol client'
     settings = 'os', 'arch', 'distro', 'build_type'
-    branch = 'devolutions-rdp-rebase-4'
+    branch = 'devolutions-rdp-rebase-5'
     python_requires = "shared/1.0.0@devolutions/stable"
     python_requires_extend = "shared.UtilsBase"
 
@@ -92,7 +92,14 @@ class FreerdpConan(ConanFile):
                 cmake.definitions['WITH_NEON'] = 'ON'
 
         if self.settings.os == 'Windows':
+            cmake.definitions['CMAKE_SYSTEM_VERSION'] = '10.0.19041.0'
             cmake.definitions['MSVC_RUNTIME'] = 'static'
+
+        if self.settings.os == 'Linux':
+            cmake.definitions['WITH_INTERPROCEDURAL_OPTIMIZATION'] = 'OFF' # Currently not working in cbake
+
+        if self.settings.os == 'Android' and self.settings.arch == 'armv7':
+            cmake.definitions['WITH_INTERPROCEDURAL_OPTIMIZATION'] = 'OFF' # IPO doesn't seem to work on android-arm7
 
         openssl_path = self.deps_cpp_info['openssl'].rootpath
         winpr_path = self.deps_cpp_info['winpr'].rootpath

--- a/recipes/winpr/conanfile.py
+++ b/recipes/winpr/conanfile.py
@@ -9,7 +9,7 @@ class WinprConan(ConanFile):
     url = 'https://github.com/Devolutions/FreeRDP.git'
     description = 'FreeRDP is a free remote desktop protocol client'
     settings = 'os', 'arch', 'distro', 'build_type'
-    branch = 'devolutions-rdp-rebase-4'
+    branch = 'devolutions-rdp-rebase-5'
     python_requires = "shared/1.0.0@devolutions/stable"
     python_requires_extend = "shared.UtilsBase"
 
@@ -54,6 +54,7 @@ class WinprConan(ConanFile):
             cmake.definitions['WITH_LIBSYSTEMD'] = 'OFF'
 
         if self.settings.os == 'Windows':
+            cmake.definitions['CMAKE_SYSTEM_VERSION'] = '10.0.19041.0'
             cmake.definitions['MSVC_RUNTIME'] = 'static'
 
         mbedtls_path = self.deps_cpp_info['mbedtls'].rootpath
@@ -62,6 +63,12 @@ class WinprConan(ConanFile):
         
         if self.settings.os == 'Android': # Android toolchain overwrites CMAKE_PREFIX_PATH
             cmake.definitions['CMAKE_FIND_ROOT_PATH'] = '%s;%s' % (mbedtls_path, zlib_path)
+
+        if self.settings.os == 'Linux':
+            cmake.definitions['WITH_INTERPROCEDURAL_OPTIMIZATION'] = 'OFF' # Currently not working in cbake
+
+        if self.settings.os == 'Android' and self.settings.arch == 'armv7':
+            cmake.definitions['WITH_INTERPROCEDURAL_OPTIMIZATION'] = 'OFF' # IPO doesn't seem to work on android-arm7
 
         cmake.configure(source_folder=os.path.join('freerdp', self.name))
 


### PR DESCRIPTION
FreeRDP is rebased on the latest upstream master (in a new branch, `devolutions-rdp-rebase-5`).

See my changes [here](https://github.com/Devolutions/FreeRDP/commit/c5c4a92ef21e48260d4d9cc358db822e7acaf8a9).

Importantly, the build system needs some fixes:

### IPO
- FreeRDP now checks if IPO is possible across the board, and enables it if so. 
- On our side, we still build Android armv7 which doesn't seem to support IPO - I don't know if this is intrinsic, or a problem with the NDK.
- The IPO check also fails on our Linux builds (for whatever reason, `CheckIPOSupported` isn't working in CBake)
- Rather than get to the bottom of this now, I wrapped the IPO check in a new option (`WITH_INTERPROCEDURAL_OPTIMIZATION`) and disable it in the relevant places.
- This minimizes the changes in the FreeRDP/WinPR cmakelists

### Windows SDK
- We need to build with a newer Windows SDK (this could be related to the move to C11?), so this is now properly configured

### GitHub
- Update to newer, non-deprecated Ubuntu runner