### PR TITLE
Pin python version on macOS

### DIFF
--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -95,6 +95,12 @@ jobs:
           sudo rm -rf /Library/Developer/CommandLineTools
           echo "CONAN_USER_HOME=/tmp" >> $GITHUB_ENV
 
+      - name: Configure macOS runner
+        if: runner.os == 'macOS'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+
       - name: Configure Linux runner
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -84,6 +84,12 @@ jobs:
 
       - name: Configure macOS runner
         if: runner.os == 'macOS'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+
+      - name: Configure macOS runner
+        if: runner.os == 'macOS'
         env:
           CMAKE_OSX_DEPLOYMENT_TARGET: "10.12"
         run: |
@@ -94,12 +100,6 @@ jobs:
           pip3 install conan==${{ env.conan-version }} invoke Jinja2 urllib3 chardet requests --upgrade
           sudo rm -rf /Library/Developer/CommandLineTools
           echo "CONAN_USER_HOME=/tmp" >> $GITHUB_ENV
-
-      - name: Configure macOS runner
-        if: runner.os == 'macOS'
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10' 
 
       - name: Configure Linux runner
         if: runner.os == 'Linux'


### PR DESCRIPTION
Builds are failing when running on macOS 11.7.1 runners, which moved to python 3.11. Despite `conan` installing (with deprecation warnings) in this environment, the tool fails to run in a subsequent build step.

Resolved by pinning the Python version to 3.10.