### PR TITLE
Fix Android build and cleanup

### DIFF
--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Check out ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -104,12 +104,8 @@ jobs:
       - name: Configure Linux runner
         if: runner.os == 'Linux'
         run: |
-          sudo apt update
-          sudo apt install ninja-build
-          sudo apt install cmake
-          sudo apt install xz-utils
-          sudo apt install nasm yasm
-          sudo apt install python3 python3-pip python3-wget python3-setuptools
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get install ninja-build cmake xz-utils nasm yasm python3 python3-pip python3-wget python3-setuptools
           pip3 install conan==${{ env.conan-version }} invoke Jinja2 urllib3 chardet requests --upgrade
           echo "CONAN_USER_HOME=/tmp" >> $GITHUB_ENV
 
@@ -131,6 +127,14 @@ jobs:
           unzip -q android-ndk-r21e-linux-x86_64.zip -d /tmp
           sudo mv /tmp/android-ndk-r21e /opt/android-ndk
           echo "ANDROID_NDK=/opt/android-ndk" >> $GITHUB_ENV
+
+          ## Pin the cmake version for now, libpng builds are failing on Android x86-64
+          ## Probably related to cmake 3.25 setting LINUX
+          ## https://gitlab.kitware.com/cmake/cmake/-/issues/24196
+          ## https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7963
+
+          pip3 install cmake==3.24.2
+          cmake --version
 
       - name: Configure conan environment
         shell: pwsh
@@ -162,7 +166,7 @@ jobs:
             $Manifest | Out-File $ManifestFile
           }
           tar -czf "${PACKAGE_NAME}.tar.gz" -C "$Env:CONAN_USER_HOME" ".conan"
-          echo "::set-output name=package_name::$PACKAGE_NAME"
+          echo "package_name=$PACKAGE_NAME" >> $Env:GITHUB_OUTPUT
 
       - name: Upload conan cache
         uses: actions/upload-artifact@v2
@@ -179,7 +183,7 @@ jobs:
     
     steps:
       - name: Check out ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Configure runner
         run: |
           sudo apt update
@@ -193,7 +197,7 @@ jobs:
           conan config install ./settings
 
       - name: Download conan data
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: download
 

--- a/.github/workflows/conan-publish.yml
+++ b/.github/workflows/conan-publish.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Check out ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure runner
         run: |

--- a/recipes/libpng/conanfile.py
+++ b/recipes/libpng/conanfile.py
@@ -49,11 +49,21 @@ class TemplateConan(ConanFile):
         cmake.definitions['PNG_SHARED'] = 'OFF'
         cmake.definitions['PNG_TESTS'] = 'OFF'
 
+        zlib_path = self.deps_cpp_info['zlib'].rootpath
+        cmake.definitions['ZLIB_ROOT_DIR'] = zlib_path
+        cmake.definitions['ZLIB_BIN_DIRS'] = os.path.join(zlib_path, 'bin')
+        cmake.definitions['ZLIB_INCLUDE_DIRS'] = os.path.join(zlib_path, 'include')
+        cmake.definitions['ZLIB_LIBRARY_DIRS'] = os.path.join(zlib_path, 'lib')
+
         if self.settings.os == 'Linux':
             cmake.definitions['CMAKE_C_FLAGS_INIT'] = '-fPIC'
-        elif self.settings.os == 'Windows':
+
+        if self.settings.os == 'Windows':
             cmake.definitions['ZLIB_LIBRARY'] = os.path.join(self.deps_cpp_info['zlib'].rootpath, 'lib', 'zlibstatic.lib')
-            cmake.definitions['ZLIB_INCLUDE_DIR'] = os.path.join(self.deps_cpp_info['zlib'].rootpath, 'include')
+        else:
+            cmake.definitions['ZLIB_LIBRARY'] = os.path.join(self.deps_cpp_info['zlib'].rootpath, 'lib', 'zlib.a')
+
+        cmake.definitions['ZLIB_INCLUDE_DIR'] = os.path.join(self.deps_cpp_info['zlib'].rootpath, 'include')
 
         cmake.configure(source_folder=self.name)
 


### PR DESCRIPTION
- Pin `cmake` to 3.24.2 temporarily on Android
- Ensure we use `zlib` from `conan` on all platforms
- Fix deprecation warnings and bump action versions
- Improved robustness of `apt{-get} install` by retrying