### PR TITLE
conan-public: Android version in cbake

### DIFF
--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -58,11 +58,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         if: runner.os == 'Linux'
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         if: runner.os == 'Linux'
 
       - name: Configure Windows runner
@@ -175,37 +175,7 @@ jobs:
           path: ${{ steps.package-conan-cache.outputs.package_name }}.tar.gz
 
   publish:
-    concurrency: conan-publish
-    runs-on: ubuntu-latest
-    environment: artifactory-publish
     needs: build
     if: github.event_name != 'schedule'
-    
-    steps:
-      - name: Check out ${{ github.repository }}
-        uses: actions/checkout@v3
-      - name: Configure runner
-        run: |
-          sudo apt update
-          sudo apt install python3 python3-pip python3-wget python3-setuptools
-          pip3 install conan==${{ env.conan-version }} invoke Jinja2 urllib3 chardet requests --upgrade
-          echo "CONAN_USER_HOME=/tmp" >> $GITHUB_ENV
-
-      - name: Configure conan environment
-        run: |
-          conan config init
-          conan config install ./settings
-
-      - name: Download conan data
-        uses: actions/download-artifact@v3
-        with:
-          path: download
-
-      - name: Publish packages
-        run: pwsh ../publish.ps1
-        working-directory: download
-        env:
-          CONAN_REMOTE_NAME: "artifactory"
-          CONAN_REMOTE_URL: "https://devolutions.jfrog.io/devolutions/api/conan/conan-local"
-          CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+    uses: ./.github/workflows/conan-publish.yml
+    secrets: inherit

--- a/.github/workflows/conan-publish.yml
+++ b/.github/workflows/conan-publish.yml
@@ -6,6 +6,12 @@ on:
         description: 'run id'
         default: "1283642364"
         required: true
+  workflow_call:
+    secrets:
+      ARTIFACTORY_USERNAME:
+        required: true
+      ARTIFACTORY_PASSWORD:
+        required: true
 
 env:
    conan-version: 1.43.4
@@ -15,7 +21,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: artifactory-publish
-    
+    strategy:
+      matrix:
+        os: [ windows, macos, linux, ios, android ]
+
     steps:
       - name: Check out ${{ github.repository }}
         uses: actions/checkout@v3
@@ -25,7 +34,6 @@ jobs:
           sudo apt update
           sudo apt install python3 python3-pip python3-wget python3-setuptools
           pip3 install conan==${{ env.conan-version }} invoke Jinja2 urllib3 chardet requests --upgrade
-          bash <(wget -qO - https://aka.ms/install-powershell.sh)
           echo "CONAN_USER_HOME=/tmp" >> $GITHUB_ENV
 
       - name: Configure conan environment
@@ -34,11 +42,23 @@ jobs:
           conan config install ./settings
 
       - name: Download conan data
+        uses: actions/download-artifact@v3
+        if: github.event.inputs.runId == ''
+        with:
+          path: download
+
+      - name: Download conan data
         working-directory: download
+        if: github.event.inputs.runId != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh run download ${{ github.event.inputs.runId }}
+
+      - name: Trim downloaded data
+        working-directory: download
+        shell: pwsh
+        run: Get-ChildItem | Where-Object { !$_.FullName.Contains('${{ matrix.os }}') } | Remove-Item -Recurse
 
       - name: Publish packages
         working-directory: download

--- a/recipes/freerdp/conanfile.py
+++ b/recipes/freerdp/conanfile.py
@@ -82,9 +82,6 @@ class FreerdpConan(ConanFile):
 
         if self.settings.os == "iOS":
             cmake.definitions['WITH_IOSAUDIO'] = 'ON'
-            
-        if self.settings.os == "Android":
-            cmake.definitions['WITH_MEDIACODEC'] = 'OFF' # Android API 21+
 
         if self.settings.arch in ['x86', 'x86_64']:
             cmake.definitions['WITH_SSE2'] = 'ON'

--- a/settings/profiles/android-arm
+++ b/settings/profiles/android-arm
@@ -2,4 +2,4 @@ include(android-base)
 
 [settings]
 arch=armv7
-os.api_level=16
+os.api_level=21

--- a/settings/profiles/android-x86
+++ b/settings/profiles/android-x86
@@ -2,4 +2,4 @@ include(android-base)
 
 [settings]
 arch=x86
-os.api_level=16
+os.api_level=21


### PR DESCRIPTION
Android API level is now 21 across the board.

At the same time, pipeline and recipe improvements:

- Update actions version to remove deprecation warnings
- Re-enable MEDIACODEC in Android freerdp builds
- Remove duplication in publish workflow using workflow_call
- Use a matrix to publish packages (reducing publish time ~4x)