### PR TITLE
ci: try to fix macOS build

### DIFF
--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -132,15 +132,7 @@ jobs:
         env:
           CMAKE_OSX_DEPLOYMENT_TARGET: "10.12"
         run: |
-          brew install ninja
           brew install nasm yasm
-
-          # https://github.com/actions/runner-images/issues/11926
-
-          brew unlink cmake
-          brew tap-new $USER/local-cmake
-          brew extract --version=3.31.6 cmake $USER/local-cmake
-          brew install cmake@3.31.6
 
           pip3 install conan==${{ env.conan-version }} invoke Jinja2 urllib3 chardet requests --upgrade
           sudo rm -rf /Library/Developer/CommandLineTools


### PR DESCRIPTION
Tapping a cask in homebrew is now failing because it wants us to provide a GitHub identity (homebrew probably got updated in the `macos-latest` (`macos-15`) runner.

Actually; this isn't needed anymore: GitHub reverted the installed `cmake` version back to 3.x. We don't need to pin it.

Additionally, don't try to install `ninja`. It's already installed and creates noise in the log files.