### PR TITLE
winpr/freerdp: fix cJSON linking on macOS when Homebrew cJSON is inst…

### DIFF
--- a/recipes/winpr/conanfile.py
+++ b/recipes/winpr/conanfile.py
@@ -93,10 +93,17 @@ class WinprConan(ConanFile):
         mbedtls_path = self.deps_cpp_info['mbedtls'].rootpath
         zlib_path = self.deps_cpp_info['zlib'].rootpath
         cjson_path = self.deps_cpp_info['cjson'].rootpath
-        cmake.definitions['CMAKE_PREFIX_PATH'] = '%s;%s;%s' % (mbedtls_path, zlib_path, cjson_path)
+        # Only expose conan cJSON on macOS where a system cJSON (Homebrew) could otherwise
+        # be picked up as a dynamic library and cause unresolved symbols at link time.
+        # On Windows the JsonDetect.cmake manual detection path crashes with an empty
+        # CMAKE_SHARED_LIBRARY_PREFIX, and other platforms don't have the same problem.
+        if self.settings.os == 'Macos':
+            cmake.definitions['CMAKE_PREFIX_PATH'] = '%s;%s;%s' % (mbedtls_path, zlib_path, cjson_path)
+        else:
+            cmake.definitions['CMAKE_PREFIX_PATH'] = '%s;%s' % (mbedtls_path, zlib_path)
 
         if self.settings.os == 'Android': # Android toolchain overwrites CMAKE_PREFIX_PATH
-            cmake.definitions['CMAKE_FIND_ROOT_PATH'] = '%s;%s;%s' % (mbedtls_path, zlib_path, cjson_path)
+            cmake.definitions['CMAKE_FIND_ROOT_PATH'] = '%s;%s' % (mbedtls_path, zlib_path)
             
         # Disable IPO
         if self.settings.os == 'Linux':


### PR DESCRIPTION
…alled

WinPR was picking up Homebrew's dynamic cJSON instead of the conan-managed static one, leaving cJSON_* symbols unresolved when freerdp linked libwinpr3.a.

- winpr: add cjson as build requirement; pass conan cJSON path via CMAKE_PREFIX_PATH on macOS only (Windows JsonDetect.cmake crashes with an empty CMAKE_SHARED_LIBRARY_PREFIX when cJSON is found via manual detection)
- freerdp/FindWinPR.cmake: propagate cJSON as INTERFACE_LINK_LIBRARIES on the imported winpr target so consumers link it transitively