### PR TITLE
Add iOS simulator Conan target

### DIFF
--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -53,9 +53,9 @@ jobs:
         run: |
           $Jobs = @()
           if ($Env:CONAN_MAJOR_VERSION -eq '2') {
-            @('windows', 'macos', 'linux', 'ios', 'android') | Foreach-Object {
+            @('windows', 'macos', 'linux', 'ios', 'iossimulator', 'android') | Foreach-Object {
               $Platform = $_
-              $Architectures = @('x86_64', 'aarch64')
+              $Architectures = if ($Platform -Eq 'iossimulator') { @('arm64') } else { @('x86_64', 'aarch64') }
 
               if ($Platform -Eq 'android') {
                 $Architectures += 'arm'
@@ -79,7 +79,7 @@ jobs:
                     os = $Platform
                     runner = switch ($Platform) {
                       'windows' { 'windows-2022' }
-                      { @('macos', 'ios') -contains $_ } { 'macos-latest' }
+                      { @('macos', 'ios', 'iossimulator') -contains $_ } { 'macos-latest' }
                       { @('linux', 'android') -contains $_ } { 'ubuntu-22.04' }
                     }
                   }
@@ -106,9 +106,9 @@ jobs:
             return
           }
 
-          @('windows', 'macos', 'linux', 'ios', 'android') | Foreach-Object {
+          @('windows', 'macos', 'linux', 'ios', 'iossimulator', 'android') | Foreach-Object {
             $Platform = $_
-            $Architectures = @('x86_64', 'aarch64')
+            $Architectures = if ($Platform -Eq 'iossimulator') { @('arm64') } else { @('x86_64', 'aarch64') }
 
             if($Platform -Eq 'android') {
                 $Architectures += 'arm'
@@ -132,7 +132,7 @@ jobs:
                         os = $Platform
                         runner = switch ($Platform) {
                             "windows" { "windows-2022" }
-                            { @("macos", "ios") -contains $_ } { "macos-latest" }
+                            { @("macos", "ios", "iossimulator") -contains $_ } { "macos-latest" }
                             { @("linux", "android") -contains $_ } { "ubuntu-22.04" }
                         }
                     }

--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -230,7 +230,11 @@ jobs:
         env:
           CMAKE_OSX_DEPLOYMENT_TARGET: "10.12"
         run: |
-          sudo xcode-select --switch /Applications/Xcode_16.4.app
+          if [ -d /Applications/Xcode_16.4.app ]; then
+            sudo xcode-select --switch /Applications/Xcode_16.4.app
+          else
+            echo "Xcode_16.4.app is not installed; keeping the default Xcode selection."
+          fi
 
       - name: Configure macOS runner
         if: runner.os == 'macOS'

--- a/.github/workflows/conan-publish.yml
+++ b/.github/workflows/conan-publish.yml
@@ -47,7 +47,7 @@ jobs:
       name: ${{ inputs.dry_run && 'conan-publish-dry-run' || 'artifactory-publish' }}
     strategy:
       matrix:
-        os: [ windows, macos, ios, android, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        os: [ windows, macos, ios, iossimulator, android, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
 
     steps:
       - name: Check out ${{ github.repository }}
@@ -91,7 +91,15 @@ jobs:
       - name: Trim downloaded data
         working-directory: download
         shell: pwsh
-        run: Get-ChildItem | Where-Object { !$_.FullName.Contains('${{ matrix.os }}') } | Remove-Item -Recurse
+        run: |
+          $TargetName = '${{ matrix.os }}'
+          Get-ChildItem | Where-Object {
+            $ArtifactTarget = $null
+            if ($_.Name -match '^conan[12]-[^-]+-(?<target>.+)-(Debug|Release|RelWithDebInfo)$') {
+              $ArtifactTarget = $Matches['target']
+            }
+            $ArtifactTarget -ne $TargetName
+          } | Remove-Item -Recurse
 
       - name: Validate packages ${{ matrix.os }}
         if: ${{ inputs.dry_run }}

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Build existing packages with the current PowerShell entry point:
 
 ## Conan 2 migration workflow
 
-Conan 2 has parallel build coverage for the current Conan 1 package set across Windows, macOS, iOS, Android, and Linux. Conan 1 remains the default workflow-dispatch and scheduled build path; Conan 2 can be selected with `conan_major_version=2` and also has its own scheduled validation lane. Manual package runs default to publish dry-runs with `publish_dry_run=true`; set it to `false` only when the resulting Artifactory upload is intended and approved.
+Conan 2 has parallel build coverage for the current Conan 1 package set across Windows, macOS, iOS, iOS simulator, Android, and Linux. Conan 1 remains the default workflow-dispatch and scheduled build path; Conan 2 can be selected with `conan_major_version=2` and also has its own scheduled validation lane. Manual package runs default to publish dry-runs with `publish_dry_run=true`; set it to `false` only when the resulting Artifactory upload is intended and approved.
 
 The default local Conan 2 smoke-test lane is:
 
@@ -123,6 +123,27 @@ Before porting a recipe, build the original Conan 1 recipe on the same machine a
 
 `scripts\test-conan2-recipe.ps1` defaults to `windows`, `x86_64`, and `Debug`. It also supports `x86`, `x64`/`x86_64`, `arm64`/`aarch64`, `Debug`, `Release`, and `RelWithDebInfo`. It runs `conan2 create` with the detected default Conan 2 profiles and `--build=missing` so each recipe can be iterated quickly from a normal local terminal.
 On Windows, the helper uses Ninja and automatically enters the Visual Studio `vcvarsall.bat` compiler environment for the requested target architecture when `cl.exe` is not already on PATH.
+
+### iOS simulator arm64 packages
+
+Use `iossimulator` when building arm64 simulator packages. This keeps the existing `ios-arm64`/`ios-aarch64` device target unchanged while making the simulator SDK explicit.
+
+Conan 1 uses checked-in profiles from `settings\profiles`; `iossimulator-arm64` is the primary profile and `iossimulator-aarch64` is an alias:
+
+```powershell
+conan1 config install .\settings
+.\build.ps1 -Platform iossimulator -Architecture arm64 -BuildType Release
+.\scripts\test-conan1-recipe.ps1 zlib -Platform iossimulator -Architecture arm64
+```
+
+Conan 2 derives the same target from script arguments and emits `os=iOS`, `arch=armv8`, and `os.sdk=iphonesimulator`:
+
+```powershell
+.\scripts\test-conan2-recipe.ps1 zlib -Platform iossimulator -Architecture arm64 -BuildType Debug
+.\scripts\build-conan2.ps1 -Platform iossimulator -Architecture arm64 -BuildType Release
+```
+
+iOS simulator package builds require a macOS runner with Xcode.
 
 ### Linux x86_64 Debug iteration
 

--- a/build.ps1
+++ b/build.ps1
@@ -70,7 +70,7 @@ function Get-TlkPlatform {
 
 function Invoke-TlkBuild {
 	param(
-		[ValidateSet('windows','macos','linux','ios','android')]
+		[ValidateSet('windows','macos','linux','ios','iossimulator','android')]
 		[string] $Platform,
 		[ValidateSet('x86','x86_64','arm','arm64','aarch64')]
 		[string] $Architecture = "x86_64",

--- a/conan1/recipes/mbedtls/conanfile.py
+++ b/conan1/recipes/mbedtls/conanfile.py
@@ -15,7 +15,8 @@ class MbedtlsConan(ConanFile):
         'patches/0002-aes-ni-use-target-attributes-for-32-bit-intrinsics.patch',
         'patches/0003-fix-build-for-windows-arm64-neon-and-aes-extensions.patch',
         'patches/0004-add-support-for-mbedtls-ssl-verify-external-authmode.patch',
-        'patches/0005-fix-tls13-keys-cast-build-warning.patch']
+        'patches/0005-fix-tls13-keys-cast-build-warning.patch',
+        'patches/0006-fix-tls13-label-array-initializers.patch']
 
     options = {
         'fPIC': [True, False],
@@ -60,8 +61,6 @@ class MbedtlsConan(ConanFile):
 
         if self.settings.os == 'Windows':
             cmake.definitions['MSVC_STATIC_RUNTIME'] = 'ON'
-        elif self.settings.os in ['iOS', 'Macos']:
-            cmake.definitions['CMAKE_C_FLAGS'] = '-Wno-unknown-warning-option -Wno-unterminated-string-initialization'
 
         if self.settings.os == 'Windows':
             mbedtls_configs.extend(['MBEDTLS_THREADING_WINDOWS'])

--- a/conan1/recipes/mbedtls/conanfile.py
+++ b/conan1/recipes/mbedtls/conanfile.py
@@ -60,6 +60,8 @@ class MbedtlsConan(ConanFile):
 
         if self.settings.os == 'Windows':
             cmake.definitions['MSVC_STATIC_RUNTIME'] = 'ON'
+        elif self.settings.os in ['iOS', 'Macos']:
+            cmake.definitions['CMAKE_C_FLAGS'] = '-Wno-unterminated-string-initialization'
 
         if self.settings.os == 'Windows':
             mbedtls_configs.extend(['MBEDTLS_THREADING_WINDOWS'])

--- a/conan1/recipes/mbedtls/conanfile.py
+++ b/conan1/recipes/mbedtls/conanfile.py
@@ -61,7 +61,7 @@ class MbedtlsConan(ConanFile):
         if self.settings.os == 'Windows':
             cmake.definitions['MSVC_STATIC_RUNTIME'] = 'ON'
         elif self.settings.os in ['iOS', 'Macos']:
-            cmake.definitions['CMAKE_C_FLAGS'] = '-Wno-unterminated-string-initialization'
+            cmake.definitions['CMAKE_C_FLAGS'] = '-Wno-unknown-warning-option -Wno-unterminated-string-initialization'
 
         if self.settings.os == 'Windows':
             mbedtls_configs.extend(['MBEDTLS_THREADING_WINDOWS'])

--- a/conan1/recipes/mbedtls/conanfile.py
+++ b/conan1/recipes/mbedtls/conanfile.py
@@ -40,7 +40,7 @@ class MbedtlsConan(ConanFile):
 
         patches_dir = os.path.join(self.recipe_folder, "patches")
         if os.path.isdir(patches_dir):
-            for patch_file in os.listdir(patches_dir):
+            for patch_file in sorted(os.listdir(patches_dir)):
                 patch_path = os.path.join(patches_dir, patch_file)
                 self.output.info('Applying patch: %s' % patch_path)
                 tools.patch(base_path=folder, patch_file=patch_path)

--- a/conan1/recipes/mbedtls/conanfile.py
+++ b/conan1/recipes/mbedtls/conanfile.py
@@ -16,7 +16,8 @@ class MbedtlsConan(ConanFile):
         'patches/0003-fix-build-for-windows-arm64-neon-and-aes-extensions.patch',
         'patches/0004-add-support-for-mbedtls-ssl-verify-external-authmode.patch',
         'patches/0005-fix-tls13-keys-cast-build-warning.patch',
-        'patches/0006-fix-tls13-label-array-initializers.patch']
+        'patches/0006-fix-tls13-label-array-initializers.patch',
+        'patches/0007-fix-tls13-prefix-array-initializer.patch']
 
     options = {
         'fPIC': [True, False],

--- a/conan1/recipes/mbedtls/patches/0006-fix-tls13-label-array-initializers.patch
+++ b/conan1/recipes/mbedtls/patches/0006-fix-tls13-label-array-initializers.patch
@@ -12,7 +12,7 @@ diff --git a/library/ssl_tls13_keys.c b/library/ssl_tls13_keys.c
 index ed701d648..16c4b20db 100644
 --- a/library/ssl_tls13_keys.c
 +++ b/library/ssl_tls13_keys.c
-@@ -50,8 +50,8 @@ static int local_err_translation(psa_status_t status)
+@@ -51,8 +51,8 @@
  
  struct mbedtls_ssl_tls13_labels_struct const mbedtls_ssl_tls13_labels =
  {
@@ -27,7 +27,7 @@ diff --git a/library/ssl_tls13_keys.h b/library/ssl_tls13_keys.h
 index 46fb4e392..d5f6ca94e 100644
 --- a/library/ssl_tls13_keys.h
 +++ b/library/ssl_tls13_keys.h
-@@ -42,7 +42,7 @@
+@@ -41,7 +41,7 @@
  #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
  
  #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
@@ -36,7 +36,7 @@ index 46fb4e392..d5f6ca94e 100644
  
  union mbedtls_ssl_tls13_labels_union {
      MBEDTLS_SSL_TLS1_3_LABEL_LIST
-@@ -57,6 +57,6 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
+@@ -55,6 +55,6 @@
  
  #define MBEDTLS_SSL_TLS1_3_LBL_LEN(LABEL)  \
 -    sizeof(mbedtls_ssl_tls13_labels.LABEL)
@@ -44,7 +44,7 @@ index 46fb4e392..d5f6ca94e 100644
  
  #define MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN(LABEL)  \
      mbedtls_ssl_tls13_labels.LABEL,              \
-@@ -65,6 +65,6 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
+@@ -62,6 +62,6 @@
  
  #define MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_LABEL_LEN  \
 -    sizeof(union mbedtls_ssl_tls13_labels_union)

--- a/conan1/recipes/mbedtls/patches/0006-fix-tls13-label-array-initializers.patch
+++ b/conan1/recipes/mbedtls/patches/0006-fix-tls13-label-array-initializers.patch
@@ -1,0 +1,56 @@
+From b3a87d7475428d6395df8431acbe0e5d0509a569 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marc-Andr=C3=A9=20Moreau?= <mamoreau@devolutions.net>
+Date: Mon, 29 Jun 2026 12:33:00 -0400
+Subject: [PATCH] fix TLS 1.3 label array initializers
+
+---
+ library/ssl_tls13_keys.c | 4 ++--
+ library/ssl_tls13_keys.h | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/library/ssl_tls13_keys.c b/library/ssl_tls13_keys.c
+index ed701d648..16c4b20db 100644
+--- a/library/ssl_tls13_keys.c
++++ b/library/ssl_tls13_keys.c
+@@ -50,8 +50,8 @@ static int local_err_translation(psa_status_t status)
+ 
+ struct mbedtls_ssl_tls13_labels_struct const mbedtls_ssl_tls13_labels =
+ {
+-    /* This seems to work in C, despite the string literal being one
+-     * character too long due to the 0-termination. */
++    /* Store the terminator in each array; public label lengths exclude it.
++     * Newer Apple Clang rejects truncating string literal initializers. */
+     MBEDTLS_SSL_TLS1_3_LABEL_LIST
+ };
+ 
+diff --git a/library/ssl_tls13_keys.h b/library/ssl_tls13_keys.h
+index 46fb4e392..d5f6ca94e 100644
+--- a/library/ssl_tls13_keys.h
++++ b/library/ssl_tls13_keys.h
+@@ -42,7 +42,7 @@
+ #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+ 
+ #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
+-    const unsigned char name    [sizeof(string) - 1];
++    const unsigned char name    [sizeof(string)];
+ 
+ union mbedtls_ssl_tls13_labels_union {
+     MBEDTLS_SSL_TLS1_3_LABEL_LIST
+@@ -57,6 +57,6 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
+ 
+ #define MBEDTLS_SSL_TLS1_3_LBL_LEN(LABEL)  \
+-    sizeof(mbedtls_ssl_tls13_labels.LABEL)
++    (sizeof(mbedtls_ssl_tls13_labels.LABEL) - 1)
+ 
+ #define MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN(LABEL)  \
+     mbedtls_ssl_tls13_labels.LABEL,              \
+@@ -65,6 +65,6 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
+ 
+ #define MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_LABEL_LEN  \
+-    sizeof(union mbedtls_ssl_tls13_labels_union)
++    (sizeof(union mbedtls_ssl_tls13_labels_union) - 1)
+ 
+ /* The maximum length of HKDF contexts used in the TLS 1.3 standard.
+  * Since contexts are always hashes of message transcripts, this can
+-- 
+2.25.1

--- a/conan1/recipes/mbedtls/patches/0007-fix-tls13-prefix-array-initializer.patch
+++ b/conan1/recipes/mbedtls/patches/0007-fix-tls13-prefix-array-initializer.patch
@@ -1,0 +1,49 @@
+From 5368a04f65acb322c4e07224d09a5d4eecbca1d2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marc-Andr=C3=A9=20Moreau?= <mamoreau@devolutions.net>
+Date: Mon, 29 Jun 2026 13:11:00 -0400
+Subject: [PATCH] fix TLS 1.3 prefix array initializer
+
+---
+ library/ssl_tls13_keys.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/library/ssl_tls13_keys.c b/library/ssl_tls13_keys.c
+index 16c4b20db..91fd8a4ef 100644
+--- a/library/ssl_tls13_keys.c
++++ b/library/ssl_tls13_keys.c
+@@ -95,5 +95,6 @@
+ 
+-static const char tls13_label_prefix[6] = "tls13 ";
++static const char tls13_label_prefix[] = "tls13 ";
++#define SSL_TLS1_3_LABEL_PREFIX_LEN (sizeof(tls13_label_prefix) - 1)
+ 
+ #define SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(label_len, context_len) \
+     (2                     /* expansion length           */ \
+@@ -105,6 +106,6 @@
+ #define SSL_TLS1_3_KEY_SCHEDULE_MAX_HKDF_LABEL_LEN                      \
+     SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(                             \
+-        sizeof(tls13_label_prefix) +                       \
++        SSL_TLS1_3_LABEL_PREFIX_LEN +                      \
+         MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_LABEL_LEN,     \
+         MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_CONTEXT_LEN)
+ 
+@@ -116,6 +117,6 @@
+ {
+     size_t total_label_len =
+-        sizeof(tls13_label_prefix) + label_len;
++        SSL_TLS1_3_LABEL_PREFIX_LEN + label_len;
+     size_t total_hkdf_lbl_len =
+         SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(total_label_len, ctx_len);
+ 
+@@ -135,7 +136,7 @@
+     /* Add label incl. prefix */
+     *p++ = MBEDTLS_BYTE_0(total_label_len);
+-    memcpy(p, tls13_label_prefix, sizeof(tls13_label_prefix));
+-    p += sizeof(tls13_label_prefix);
++    memcpy(p, tls13_label_prefix, SSL_TLS1_3_LABEL_PREFIX_LEN);
++    p += SSL_TLS1_3_LABEL_PREFIX_LEN;
+     memcpy(p, label, label_len);
+     p += label_len;
+ 
+-- 
+2.25.1

--- a/conan1/recipes/shared/conanfile.py
+++ b/conan1/recipes/shared/conanfile.py
@@ -153,6 +153,8 @@ class UtilsBase(object):
             cmake.definitions['CMAKE_TOOLCHAIN_FILE'] = os.path.join(cbake_home, 'cmake', 'ios-%s.toolchain.cmake' % ios_arch)
             cmake.definitions['IOS_DEPLOYMENT_TARGET'] = os_version
             cmake.definitions['CMAKE_OSX_ARCHITECTURES'] = ios_arch
+            if str(settings.os.sdk) == 'iphonesimulator':
+                cmake.definitions['IOS_PLATFORM'] = 'SIMULATOR'
             cmake.generator = 'Ninja'
         elif target_os == 'Android':
             abi = {'armv7': 'armeabi-v7a with NEON', 'armv8': 'arm64-v8a', 'x86': 'x86', 'x86_64': 'x86_64'}[target_arch]

--- a/conan2/recipes/mbedtls/conanfile.py
+++ b/conan2/recipes/mbedtls/conanfile.py
@@ -54,6 +54,8 @@ class MbedtlsConan(ConanFile):
         if self.settings.os == "Windows":
             tc.variables["MSVC_STATIC_RUNTIME"] = True
             tc.variables["CMAKE_MSVC_RUNTIME_LIBRARY"] = "MultiThreadedDebug" if self.settings.build_type == "Debug" else "MultiThreaded"
+        elif self.settings.os in ["iOS", "Macos"]:
+            tc.variables["CMAKE_C_FLAGS"] = "-Wno-unterminated-string-initialization"
         tc.generate()
 
     def build(self):

--- a/conan2/recipes/mbedtls/conanfile.py
+++ b/conan2/recipes/mbedtls/conanfile.py
@@ -55,7 +55,7 @@ class MbedtlsConan(ConanFile):
             tc.variables["MSVC_STATIC_RUNTIME"] = True
             tc.variables["CMAKE_MSVC_RUNTIME_LIBRARY"] = "MultiThreadedDebug" if self.settings.build_type == "Debug" else "MultiThreaded"
         elif self.settings.os in ["iOS", "Macos"]:
-            tc.variables["CMAKE_C_FLAGS"] = "-Wno-unterminated-string-initialization"
+            tc.variables["CMAKE_C_FLAGS"] = "-Wno-unknown-warning-option -Wno-unterminated-string-initialization"
         tc.generate()
 
     def build(self):

--- a/conan2/recipes/mbedtls/conanfile.py
+++ b/conan2/recipes/mbedtls/conanfile.py
@@ -54,8 +54,6 @@ class MbedtlsConan(ConanFile):
         if self.settings.os == "Windows":
             tc.variables["MSVC_STATIC_RUNTIME"] = True
             tc.variables["CMAKE_MSVC_RUNTIME_LIBRARY"] = "MultiThreadedDebug" if self.settings.build_type == "Debug" else "MultiThreaded"
-        elif self.settings.os in ["iOS", "Macos"]:
-            tc.variables["CMAKE_C_FLAGS"] = "-Wno-unknown-warning-option -Wno-unterminated-string-initialization"
         tc.generate()
 
     def build(self):

--- a/conan2/recipes/mbedtls/patches/0006-fix-tls13-label-array-initializers.patch
+++ b/conan2/recipes/mbedtls/patches/0006-fix-tls13-label-array-initializers.patch
@@ -12,7 +12,7 @@ diff --git a/library/ssl_tls13_keys.c b/library/ssl_tls13_keys.c
 index ed701d648..16c4b20db 100644
 --- a/library/ssl_tls13_keys.c
 +++ b/library/ssl_tls13_keys.c
-@@ -50,8 +50,8 @@ static int local_err_translation(psa_status_t status)
+@@ -51,8 +51,8 @@
  
  struct mbedtls_ssl_tls13_labels_struct const mbedtls_ssl_tls13_labels =
  {
@@ -27,7 +27,7 @@ diff --git a/library/ssl_tls13_keys.h b/library/ssl_tls13_keys.h
 index 46fb4e392..d5f6ca94e 100644
 --- a/library/ssl_tls13_keys.h
 +++ b/library/ssl_tls13_keys.h
-@@ -42,7 +42,7 @@
+@@ -41,7 +41,7 @@
  #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
  
  #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
@@ -36,7 +36,7 @@ index 46fb4e392..d5f6ca94e 100644
  
  union mbedtls_ssl_tls13_labels_union {
      MBEDTLS_SSL_TLS1_3_LABEL_LIST
-@@ -57,6 +57,6 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
+@@ -55,6 +55,6 @@
  
  #define MBEDTLS_SSL_TLS1_3_LBL_LEN(LABEL)  \
 -    sizeof(mbedtls_ssl_tls13_labels.LABEL)
@@ -44,7 +44,7 @@ index 46fb4e392..d5f6ca94e 100644
  
  #define MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN(LABEL)  \
      mbedtls_ssl_tls13_labels.LABEL,              \
-@@ -65,6 +65,6 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
+@@ -62,6 +62,6 @@
  
  #define MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_LABEL_LEN  \
 -    sizeof(union mbedtls_ssl_tls13_labels_union)

--- a/conan2/recipes/mbedtls/patches/0006-fix-tls13-label-array-initializers.patch
+++ b/conan2/recipes/mbedtls/patches/0006-fix-tls13-label-array-initializers.patch
@@ -1,0 +1,56 @@
+From b3a87d7475428d6395df8431acbe0e5d0509a569 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marc-Andr=C3=A9=20Moreau?= <mamoreau@devolutions.net>
+Date: Mon, 29 Jun 2026 12:33:00 -0400
+Subject: [PATCH] fix TLS 1.3 label array initializers
+
+---
+ library/ssl_tls13_keys.c | 4 ++--
+ library/ssl_tls13_keys.h | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/library/ssl_tls13_keys.c b/library/ssl_tls13_keys.c
+index ed701d648..16c4b20db 100644
+--- a/library/ssl_tls13_keys.c
++++ b/library/ssl_tls13_keys.c
+@@ -50,8 +50,8 @@ static int local_err_translation(psa_status_t status)
+ 
+ struct mbedtls_ssl_tls13_labels_struct const mbedtls_ssl_tls13_labels =
+ {
+-    /* This seems to work in C, despite the string literal being one
+-     * character too long due to the 0-termination. */
++    /* Store the terminator in each array; public label lengths exclude it.
++     * Newer Apple Clang rejects truncating string literal initializers. */
+     MBEDTLS_SSL_TLS1_3_LABEL_LIST
+ };
+ 
+diff --git a/library/ssl_tls13_keys.h b/library/ssl_tls13_keys.h
+index 46fb4e392..d5f6ca94e 100644
+--- a/library/ssl_tls13_keys.h
++++ b/library/ssl_tls13_keys.h
+@@ -42,7 +42,7 @@
+ #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
+ 
+ #define MBEDTLS_SSL_TLS1_3_LABEL(name, string)       \
+-    const unsigned char name    [sizeof(string) - 1];
++    const unsigned char name    [sizeof(string)];
+ 
+ union mbedtls_ssl_tls13_labels_union {
+     MBEDTLS_SSL_TLS1_3_LABEL_LIST
+@@ -57,6 +57,6 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
+ 
+ #define MBEDTLS_SSL_TLS1_3_LBL_LEN(LABEL)  \
+-    sizeof(mbedtls_ssl_tls13_labels.LABEL)
++    (sizeof(mbedtls_ssl_tls13_labels.LABEL) - 1)
+ 
+ #define MBEDTLS_SSL_TLS1_3_LBL_WITH_LEN(LABEL)  \
+     mbedtls_ssl_tls13_labels.LABEL,              \
+@@ -65,6 +65,6 @@ extern const struct mbedtls_ssl_tls13_labels_struct mbedtls_ssl_tls13_labels;
+ 
+ #define MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_LABEL_LEN  \
+-    sizeof(union mbedtls_ssl_tls13_labels_union)
++    (sizeof(union mbedtls_ssl_tls13_labels_union) - 1)
+ 
+ /* The maximum length of HKDF contexts used in the TLS 1.3 standard.
+  * Since contexts are always hashes of message transcripts, this can
+-- 
+2.25.1

--- a/conan2/recipes/mbedtls/patches/0007-fix-tls13-prefix-array-initializer.patch
+++ b/conan2/recipes/mbedtls/patches/0007-fix-tls13-prefix-array-initializer.patch
@@ -1,0 +1,49 @@
+From 5368a04f65acb322c4e07224d09a5d4eecbca1d2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marc-Andr=C3=A9=20Moreau?= <mamoreau@devolutions.net>
+Date: Mon, 29 Jun 2026 13:11:00 -0400
+Subject: [PATCH] fix TLS 1.3 prefix array initializer
+
+---
+ library/ssl_tls13_keys.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/library/ssl_tls13_keys.c b/library/ssl_tls13_keys.c
+index 16c4b20db..91fd8a4ef 100644
+--- a/library/ssl_tls13_keys.c
++++ b/library/ssl_tls13_keys.c
+@@ -95,5 +95,6 @@
+ 
+-static const char tls13_label_prefix[6] = "tls13 ";
++static const char tls13_label_prefix[] = "tls13 ";
++#define SSL_TLS1_3_LABEL_PREFIX_LEN (sizeof(tls13_label_prefix) - 1)
+ 
+ #define SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(label_len, context_len) \
+     (2                     /* expansion length           */ \
+@@ -105,6 +106,6 @@
+ #define SSL_TLS1_3_KEY_SCHEDULE_MAX_HKDF_LABEL_LEN                      \
+     SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(                             \
+-        sizeof(tls13_label_prefix) +                       \
++        SSL_TLS1_3_LABEL_PREFIX_LEN +                      \
+         MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_LABEL_LEN,     \
+         MBEDTLS_SSL_TLS1_3_KEY_SCHEDULE_MAX_CONTEXT_LEN)
+ 
+@@ -116,6 +117,6 @@
+ {
+     size_t total_label_len =
+-        sizeof(tls13_label_prefix) + label_len;
++        SSL_TLS1_3_LABEL_PREFIX_LEN + label_len;
+     size_t total_hkdf_lbl_len =
+         SSL_TLS1_3_KEY_SCHEDULE_HKDF_LABEL_LEN(total_label_len, ctx_len);
+ 
+@@ -135,7 +136,7 @@
+     /* Add label incl. prefix */
+     *p++ = MBEDTLS_BYTE_0(total_label_len);
+-    memcpy(p, tls13_label_prefix, sizeof(tls13_label_prefix));
+-    p += sizeof(tls13_label_prefix);
++    memcpy(p, tls13_label_prefix, SSL_TLS1_3_LABEL_PREFIX_LEN);
++    p += SSL_TLS1_3_LABEL_PREFIX_LEN;
+     memcpy(p, label, label_len);
+     p += label_len;
+ 
+-- 
+2.25.1

--- a/scripts/build-conan2.ps1
+++ b/scripts/build-conan2.ps1
@@ -2,7 +2,7 @@
 
 [CmdletBinding()]
 param(
-    [ValidateSet("windows", "linux", "macos", "ios", "android")]
+    [ValidateSet("windows", "linux", "macos", "ios", "iossimulator", "android")]
     [string] $Platform = "linux",
     [ValidateSet("x86", "x86_64", "x64", "arm", "arm64", "aarch64")]
     [string] $Architecture = "x86_64",

--- a/scripts/test-conan1-recipe.ps1
+++ b/scripts/test-conan1-recipe.ps1
@@ -5,7 +5,7 @@ param(
     [Parameter(Mandatory=$true, Position=0)]
     [string] $PackageName,
     [string] $ProfileName = "windows-x86_64",
-    [ValidateSet("windows", "linux")]
+    [ValidateSet("windows", "linux", "macos", "ios", "iossimulator", "android")]
     [string] $Platform = "windows",
     [ValidateSet("x86", "x86_64", "x64", "arm64", "aarch64")]
     [string] $Architecture = "x86_64",

--- a/scripts/test-conan2-recipe.ps1
+++ b/scripts/test-conan2-recipe.ps1
@@ -4,7 +4,7 @@
 param(
     [Parameter(Mandatory=$true, Position=0)]
     [string] $PackageName,
-    [ValidateSet("windows", "linux", "macos", "ios", "android")]
+    [ValidateSet("windows", "linux", "macos", "ios", "iossimulator", "android")]
     [string] $Platform = "windows",
     [ValidateSet("x86", "x86_64", "x64", "arm", "arm64", "aarch64")]
     [string] $Architecture = "x86_64",
@@ -62,6 +62,7 @@ function ConvertTo-ConanOs {
         "linux" { return "Linux" }
         "macos" { return "Macos" }
         "ios" { return "iOS" }
+        "iossimulator" { return "iOS" }
         "android" { return "Android" }
         default { throw "Unsupported platform '$Platform'." }
     }
@@ -87,6 +88,9 @@ function Get-ConanPlatformSettings {
         "ios" {
             $Sdk = if ($Architecture -eq "x86_64") { "iphonesimulator" } else { "iphoneos" }
             return @("os.version=9.3", "os.sdk=$Sdk")
+        }
+        "iossimulator" {
+            return @("os.version=9.3", "os.sdk=iphonesimulator")
         }
         "macos" {
             $Version = if ($Architecture -in @("armv8", "arm64", "aarch64")) { "10.15" } else { "10.9" }

--- a/settings/profiles/iossimulator-aarch64
+++ b/settings/profiles/iossimulator-aarch64
@@ -1,0 +1,2 @@
+include(iossimulator-arm64)
+

--- a/settings/profiles/iossimulator-arm64
+++ b/settings/profiles/iossimulator-arm64
@@ -1,0 +1,5 @@
+include(iossimulator-base)
+
+[settings]
+arch=armv8
+

--- a/settings/profiles/iossimulator-base
+++ b/settings/profiles/iossimulator-base
@@ -1,0 +1,9 @@
+
+[settings]
+os=iOS
+os.version=9.3
+os.sdk=iphonesimulator
+distro=None
+compiler=clang
+compiler.libcxx=libc++
+

--- a/settings/profiles/iossimulator-x86_64
+++ b/settings/profiles/iossimulator-x86_64
@@ -1,0 +1,5 @@
+include(iossimulator-base)
+
+[settings]
+arch=x86_64
+


### PR DESCRIPTION
## Summary
- add explicit `iossimulator` target support, including Conan 1 simulator profiles for arm64/aarch64
- update Conan 1 and Conan 2 build/test scripts plus CI/publish matrices for iOS simulator packages
- set `IOS_PLATFORM=SIMULATOR` for Conan 1 simulator SDK builds and document simulator usage
- patch MbedTLS TLS 1.3 string initializers so Apple Clang/Xcode CI builds pass with `-Werror`

## Validation
- Conan 1 production dry run passed: `conan-packages.yml` workflow_dispatch run `28389542619` at `2f8f844`