### PR TITLE
ci: pin Xcode for all macOS builds to stop toolchain drift

### DIFF
--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -83,7 +83,7 @@ jobs:
                     os = $Platform
                     runner = switch ($Platform) {
                       'windows' { 'windows-2022' }
-                      { @('macos', 'ios', 'iossimulator') -contains $_ } { 'macos-latest' }
+                      { @('macos', 'ios', 'iossimulator') -contains $_ } { 'macos-15' }
                       { @('linux', 'android') -contains $_ } { 'ubuntu-22.04' }
                     }
                   }
@@ -136,7 +136,7 @@ jobs:
                         os = $Platform
                         runner = switch ($Platform) {
                             "windows" { "windows-2022" }
-                            { @("macos", "ios", "iossimulator") -contains $_ } { "macos-latest" }
+                            { @("macos", "ios", "iossimulator") -contains $_ } { "macos-15" }
                             { @("linux", "android") -contains $_ } { "ubuntu-22.04" }
                         }
                     }

--- a/.github/workflows/conan-packages.yml
+++ b/.github/workflows/conan-packages.yml
@@ -22,6 +22,10 @@ on:
 env:
   conan1_version: 1.66.0
   conan2_version: '>=2,<3'
+  # Pin the macOS/iOS toolchain so published binaries (and their LTO bitcode)
+  # stay linkable by downstream consumers instead of drifting with the runner
+  # image's default Xcode. Must match a version installed on the runner.
+  xcode_version: '16.4'
   
 jobs:
   generate-matrix:
@@ -224,17 +228,22 @@ jobs:
         with:
           python-version: '3.10' 
 
-        # Pin Xcode to reduce headaches when the default switches across runner images
-      - name: Configure macOS runner
-        if: runner.os == 'macOS' && matrix.arch == 'aarch64'
-        env:
-          CMAKE_OSX_DEPLOYMENT_TARGET: "10.12"
+        # Pin Xcode for every macOS job (device, simulator and x86_64) so the
+        # toolchain is deterministic. Silently falling back to the runner's
+        # default Xcode lets newer toolchains ship bitcode/SDKs that older
+        # consumers can't link (e.g. RelWithDebInfo LTO across mismatched
+        # Xcode versions), so fail loudly if the pinned version is missing.
+      - name: Select Xcode
+        if: runner.os == 'macOS'
         run: |
-          if [ -d /Applications/Xcode_16.4.app ]; then
-            sudo xcode-select --switch /Applications/Xcode_16.4.app
-          else
-            echo "Xcode_16.4.app is not installed; keeping the default Xcode selection."
+          XCODE_APP="/Applications/Xcode_${{ env.xcode_version }}.app"
+          if [ ! -d "$XCODE_APP" ]; then
+            echo "::error::$XCODE_APP is not installed on this runner. Installed Xcodes:"
+            ls -d /Applications/Xcode_*.app 2>/dev/null || true
+            exit 1
           fi
+          sudo xcode-select --switch "$XCODE_APP"
+          xcodebuild -version
 
       - name: Configure macOS runner
         if: runner.os == 'macOS'


### PR DESCRIPTION
> **Draft — do not merge/republish until reviewed.** Requires a full rebuild+republish of macOS/iOS packages to take effect, and `xcode_version` must match a version present on the current `macos-latest` image.

## Problem
The Xcode pin added in #117 only applied to `aarch64` jobs and **silently fell back** to the runner's default Xcode when `Xcode_16.4.app` was absent:

```yaml
if: runner.os == 'macOS' && matrix.arch == 'aarch64'
run: |
  if [ -d /Applications/Xcode_16.4.app ]; then
    sudo xcode-select --switch /Applications/Xcode_16.4.app
  else
    echo "...keeping the default Xcode selection."   # <- silent drift
  fi
```

As a result, macOS/iOS packages shipped with whatever Xcode the image defaulted to, and that drifted **across matrix jobs in the same run**. Observed in run 28815273037:
- device iOS libjpeg built with **Xcode 26** (`iPhoneOS26.5.sdk`)
- simulator libjpeg built with **Xcode 16.4** (`iPhoneSimulator18.5.sdk`)

Downstream consumers doing `RelWithDebInfo` LTO then can't parse the newer bitcode:

```
ld: could not parse bitcode object file .../winpr/.../libfoo.a(foo.c.o):
    'Invalid bitcode version (Producer: '2100.1.1.101.0_0' Reader: '1700.0.13.5_0')'
```

(This broke `freevnc` `macos-aarch64-RelWithDebInfo` in Devolutions/conan-private after today's republish.)

## Change
- New top-level `xcode_version` env (default `16.4`).
- Replace the aarch64-only, silent-fallback pin with a **`Select Xcode`** step that runs for **all** macOS jobs and **fails loudly** (listing installed Xcodes) if the pinned version is missing — so drift is caught in CI rather than silently baked into published binaries.

## Reviewer notes
- Confirm `Xcode_16.4.app` is present on the current `macos-latest` image; if not, bump `xcode_version` to an installed version (the failing step now prints the list).
- Merging alone changes nothing already on Artifactory — a rebuild+republish is required to correct the drifted packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)