### PR TITLE
conan-public: force cJSON backend for WinPR on Apple platforms (conan 2)

### DIFF
--- a/conan2/recipes/winpr/conanfile.py
+++ b/conan2/recipes/winpr/conanfile.py
@@ -106,8 +106,15 @@ class WinprConan(ConanFile):
         tc.variables["MBEDCRYPTO_LIBRARY"] = f"{mbedtls_path}/lib/mbedcrypto.lib" if self.settings.os == "Windows" else f"{mbedtls_path}/lib/libmbedcrypto.a"
         tc.variables["MBEDX509_LIBRARY"] = f"{mbedtls_path}/lib/mbedx509.lib" if self.settings.os == "Windows" else f"{mbedtls_path}/lib/libmbedx509.a"
         tc.variables["ZLIB_ROOT"] = zlib_path
-        if self.settings.os == "Macos":
+        # Expose conan cJSON on Apple platforms where a system json-c/cJSON (Homebrew on the
+        # macOS build host) could otherwise be picked up. WinPR's JsonDetect prefers json-c
+        # over cJSON, so simply adding cJSON to the prefix path is not enough: force cJSON as
+        # the required backend so json-c/jansson detection is skipped entirely. Without this,
+        # libwinpr3.a is compiled with the json-c backend and the final link fails with
+        # unresolved json_object_*/json_tokener_* symbols (only libcjson is provided).
+        if self.settings.os in ("Macos", "iOS"):
             tc.variables["CMAKE_PREFIX_PATH"] = ";".join([mbedtls_path, zlib_path, cjson_path])
+            tc.variables["WITH_CJSON_REQUIRED"] = True
         else:
             tc.variables["CMAKE_PREFIX_PATH"] = ";".join([mbedtls_path, zlib_path])
 


### PR DESCRIPTION
Port the conan 1 fix (938eed2) to the conan 2 recipe. The macOS/iOS builds are cross-compiled on macOS hosts that now have a Homebrew json-c installed. WinPR's JsonDetect prefers json-c over cJSON, so libwinpr3.a was built with the json-c backend while only conan's libcjson is provided at link time, breaking the final link with unresolved json_object_*/json_tokener_* symbols. Force WITH_CJSON_REQUIRED so only cJSON is detected, making the backend deterministic regardless of what is installed on the build host, and extend the cJSON prefix-path handling to iOS as well as macOS.